### PR TITLE
Add support for Vault SDK

### DIFF
--- a/cmd/cmd_read_ca_cert.go
+++ b/cmd/cmd_read_ca_cert.go
@@ -53,7 +53,7 @@ func readCaCert(config *config.Config) error {
 		return fmt.Errorf("could not build vault client: %v", err)
 	}
 
-	vaultOpts := []vault.VaultOpts{vault.VaultRole(config.VaultSshRole)}
+	vaultOpts := []vault.VaultOpts{}
 	signingImpl, err := vault.NewVaultSigner(vaultClient, &auth.NoAuth{}, vaultOpts...)
 	if err != nil {
 		return fmt.Errorf("could not build vault impl: %v", err)

--- a/cmd/cmd_sign_host_key.go
+++ b/cmd/cmd_sign_host_key.go
@@ -24,10 +24,10 @@ func getSignHostKeyCmd() *cobra.Command {
 	signCmd.Flags().StringP(config.FLAG_PUBKEY_FILE, "p", "", "Public key file to sign")
 	signCmd.Flags().StringP(config.FLAG_SIGNED_KEY_FILE, "s", "", "File to write signature to")
 	signCmd.Flags().Float32(config.FLAG_RENEW_THRESHOLD_PERCENTAGE, config.FLAG_RENEW_THRESHOLD_PERCENTAGE_DEFAULT, "Sign key after passing lifetime threshold (in %)")
-	signCmd.Flags().String(config.FLAG_METRICS_FILE, config.FLAG_METRICS_FILE_DEFAULT, "File to write metrics to")
+	signCmd.Flags().String(config.FLAG_METRICS_FILE, "", "File to write metrics to")
 
 	viper.SetDefault(config.FLAG_RENEW_THRESHOLD_PERCENTAGE, config.FLAG_RENEW_THRESHOLD_PERCENTAGE_DEFAULT)
-	viper.SetDefault(config.FLAG_METRICS_FILE, config.FLAG_METRICS_FILE_DEFAULT)
+	viper.SetDefault(config.FLAG_METRICS_FILE, "")
 
 	return signCmd
 }

--- a/cmd/cmd_sign_user_key.go
+++ b/cmd/cmd_sign_user_key.go
@@ -24,10 +24,10 @@ func getSignUserKeyCmd() *cobra.Command {
 	signCmd.Flags().StringP(config.FLAG_PUBKEY_FILE, "p", "", "Public key file to sign")
 	signCmd.Flags().StringP(config.FLAG_SIGNED_KEY_FILE, "s", "", "File to write signature to")
 	signCmd.Flags().Float32(config.FLAG_RENEW_THRESHOLD_PERCENTAGE, config.FLAG_RENEW_THRESHOLD_PERCENTAGE_DEFAULT, "Sign key after passing lifetime threshold (in %)")
-	signCmd.Flags().String(config.FLAG_METRICS_FILE, config.FLAG_METRICS_FILE_DEFAULT, "File to write metrics to")
+	signCmd.Flags().String(config.FLAG_METRICS_FILE, "", "File to write metrics to")
 
 	viper.SetDefault(config.FLAG_RENEW_THRESHOLD_PERCENTAGE, config.FLAG_RENEW_THRESHOLD_PERCENTAGE_DEFAULT)
-	viper.SetDefault(config.FLAG_METRICS_FILE, config.FLAG_METRICS_FILE_DEFAULT)
+	viper.SetDefault(config.FLAG_METRICS_FILE, "")
 
 	return signCmd
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -32,7 +32,7 @@ func main() {
 			log.Info().Msgf("Starting up version %s (%s)", internal.BuildVersion, internal.CommitHash)
 
 			var errs []error
-			cmd.Flags().Visit(func(flag *pflag.Flag) {
+			cmd.Flags().VisitAll(func(flag *pflag.Flag) {
 				err := viper.BindPFlag(flag.Name, cmd.Flags().Lookup(flag.Name))
 				if err != nil {
 					errs = append(errs, err)
@@ -46,7 +46,9 @@ func main() {
 	}
 
 	root.PersistentFlags().StringP(config.FLAG_VAULT_ADDRESS, "a", "", "Vault instance to connect to. If not specified, falls back to env var VAULT_ADDR.")
+	viper.BindEnv(config.FLAG_VAULT_ADDRESS, "VAULT_ADDR")
 	root.PersistentFlags().StringP(config.FLAG_VAULT_AUTH_TOKEN, "t", "", "Vault token to use for authentication. Can not be used in conjunction with AppRole login data.")
+	viper.BindEnv(config.FLAG_VAULT_AUTH_TOKEN, "VAULT_TOKEN")
 	root.PersistentFlags().BoolP(config.FLAG_VAULT_AUTH_IMPLICIT, "i", false, "Try to implicitly authenticate to vault using VAULT_TOKEN env var or ~/.vault-token file.")
 	root.PersistentFlags().StringP(config.FLAG_VAULT_AUTH_APPROLE_ROLE_ID, "", "", "Vault role_id to use for AppRole login. Can not be used in conjuction with Vault token flag.")
 	root.PersistentFlags().StringP(config.FLAG_VAULT_AUTH_APPROLE_SECRET_ID, "", "", "Vault secret_id to use for AppRole login. Can not be used in conjuction with Vault token flag.")

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -23,7 +23,6 @@ const (
 	FLAG_SIGNED_KEY_FILE = "signed-key-file"
 	FLAG_CONFIG_FILE     = "config-file"
 
-	FLAG_METRICS_FILE         = "metrics-file"
-	FLAG_METRICS_FILE_DEFAULT = "/var/lib/node_exporter/vault-ssh-cli.prom"
-	FLAG_DEBUG                = "debug"
+	FLAG_METRICS_FILE = "metrics-file"
+	FLAG_DEBUG        = "debug"
 )


### PR DESCRIPTION
Change:
- Full support of VAULT_ADDR & VAULT_TOKEN vars
- Viper visitor change in favor of VisitAll to be able to overide all config with Env Vars
- Remove default value of metrics since not all users needs them.