### PR TITLE
Fix `read-ca` to use SshMountPath instead of VaultRole

### DIFF
--- a/cmd/cmd_read_ca_cert.go
+++ b/cmd/cmd_read_ca_cert.go
@@ -57,7 +57,7 @@ func readCaCert(config *config.Config) error {
 		return fmt.Errorf("could not build vault client: %v", err)
 	}
 
-	vaultOpts := []vault.VaultOpts{vault.VaultRole(config.VaultSshRole)}
+	vaultOpts := []vault.VaultOpts{vault.SshMountPath(config.VaultMountSsh)}
 	signingImpl, err := vault.NewVaultSigner(vaultClient, &auth.NoAuth{}, vaultOpts...)
 	if err != nil {
 		return fmt.Errorf("could not build vault impl: %v", err)

--- a/internal/signature/vault/vault_opts.go
+++ b/internal/signature/vault/vault_opts.go
@@ -16,7 +16,7 @@ func SshMountPath(path string) VaultOpts {
 func VaultRole(role string) VaultOpts {
 	return func(v *SignatureClient) error {
 		if len(role) == 0 {
-			return errors.New("empty path provided")
+			return errors.New("empty role provided")
 		}
 
 		v.role = role


### PR DESCRIPTION
Fixes #121, see there for details

Also adapts the (probably copy-pasted) error message for an empty role.